### PR TITLE
Fix possible ref. counting issue

### DIFF
--- a/src/main/java/dev/linfoot/modapi/HypixelFabricModExample.java
+++ b/src/main/java/dev/linfoot/modapi/HypixelFabricModExample.java
@@ -61,8 +61,13 @@ public class HypixelFabricModExample implements ClientModInitializer {
     private void registerNetworkHandlers() {
         for (String identifier : HypixelModAPI.getInstance().getRegistry().getIdentifiers()) {
             ClientPlayNetworking.registerGlobalReceiver(new Identifier(identifier), (client, handler, buf, responseSender) -> {
+                buf.retain();
                 client.execute(() -> {
-                    HypixelModAPI.getInstance().handle(identifier, new PacketSerializer(buf));
+                    try {
+                        HypixelModAPI.getInstance().handle(identifier, new PacketSerializer(buf));
+                    } finally {
+                        buf.release();
+                    }
                 });
             });
         }


### PR DESCRIPTION
While this might not be an issue on whatever version this code was tested, at some point a scheduled task on main thread might get executed too late and buffer would already be released. This ensures that the buffer is kept alive.
